### PR TITLE
Fix schedule scrollbar

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -34,7 +34,7 @@ export default function Schedule(){
                 {day.date}
               </p>
             </div>
-            <div className="px-10 overflow-x-scroll flex gap-4 pb-4 sm:pb-0 sm:py-4">
+            <div className="px-10 overflow-x-auto flex gap-4 pb-4 sm:pb-0 sm:py-4">
               {day.activities.map((activity, i1) => (
                 <div className="flex flex-col"> 
                   <div className="text-gray3 text-md"> 


### PR DESCRIPTION
The scrollbar was appearing even on unneeded situations. Take a look at the "before" and the "after".
<hr>

**Before**:
![image](https://user-images.githubusercontent.com/76881129/182859326-ae50dab1-1e7a-4216-b0e6-be8441c78955.png)

**After**:
![image](https://user-images.githubusercontent.com/76881129/182859163-57bbf965-1871-497f-a899-f8b131d33049.png)
